### PR TITLE
Add /v1/actions API call to HetznerApi client

### DIFF
--- a/src/main/java/cloud/dnation/hetznerclient/HetznerApi.java
+++ b/src/main/java/cloud/dnation/hetznerclient/HetznerApi.java
@@ -30,6 +30,17 @@ import java.util.List;
  * For full version, check <a href="https://docs.hetzner.cloud/">official documentation</a>
  */
 public interface HetznerApi {
+
+    /**
+     * Get/poll the status of an asynchronous API on the Hetzner Cloud.
+     * <p>Normally, the rate limit of this API is higher and separate from the other API calls,
+     * as it is preferred to poll the /actions endpoint to wait for an asynchronous action to complete.</p>
+     * @param actionId the ID of the action whose status you want to poll
+     * @return the full Action object, including its current status
+     */
+    @GET("/v1/actions/{id}")
+    Call<ActionResponse> getActionById(@Path("id") Long actionId);
+
     /**
      * Get all images that matches given label expression.
      *

--- a/src/test/java/cloud/dnation/hetznerclient/BasicTest.java
+++ b/src/test/java/cloud/dnation/hetznerclient/BasicTest.java
@@ -52,6 +52,22 @@ public class BasicTest {
     }
 
     @Test
+    public void testGetActionById() throws IOException {
+        ws.enqueue(new MockResponse()
+                .setBody(resourceAsString("get-action-by-id.json"))
+        );
+        Call<ActionResponse> call = api.getActionById(603984077612933L);
+        ActionResponse result = call.execute().body();
+        assertEquals("delete_server", result.getAction().getCommand());
+        assertEquals(100, result.getAction().getProgress().intValue());
+        assertEquals("success", result.getAction().getStatus());
+        assertNull(result.getAction().getError());
+        List<IdentifiableResource> relatedResources = result.getAction().getResources();
+        assertEquals(1, relatedResources.size());
+        assertEquals(117017457L, relatedResources.get(0).getId().longValue());
+    }
+
+    @Test
     public void testGetNetworkById() throws IOException {
         ws.enqueue(new MockResponse()
                 .setBody(resourceAsString("get-network-by-id.json"))

--- a/src/test/resources/get-action-by-id.json
+++ b/src/test/resources/get-action-by-id.json
@@ -1,0 +1,17 @@
+{
+  "action": {
+    "id": 603984077612933,
+    "command": "delete_server",
+    "started": "2026-01-08T17:33:08Z",
+    "finished": "2026-01-08T17:33:13Z",
+    "progress": 100,
+    "status": "success",
+    "resources": [
+      {
+        "id": 117017457,
+        "type": "server"
+      }
+    ],
+    "error": null
+  }
+}


### PR DESCRIPTION
This will allow the polling of asynchronous actions from the Hetzner API without consuming the main rate limit of the other (main) endpoints.

## Testing

I tested the new method of the API client by integrating it in a small CLI app with my own API token and polling an action, and the response (and status) came back correctly.

I've also added a small unit test covering the "happy path" case of polling for a `server_delete` action, ensuring that all the fields are parsed + populated as expected.